### PR TITLE
Fix import order in training script

### DIFF
--- a/trainLin.py
+++ b/trainLin.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from stock_prediction import create_model, load_data
 
 from tensorflow.keras.callbacks import ModelCheckpoint, TensorBoard
@@ -6,8 +8,6 @@ import pandas as pd
 from parameters import *
 from numba import cuda
 from stockstats import StockDataFrame
-
-from __future__ import absolute_import, division, print_function, unicode_literals
 import pathlib
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/trainLin.py
+++ b/trainLin.py
@@ -6,11 +6,9 @@ from tensorflow.keras.callbacks import ModelCheckpoint, TensorBoard
 import os
 import pandas as pd
 from parameters import *
-from numba import cuda
 from stockstats import StockDataFrame
 import pathlib
 import matplotlib.pyplot as plt
-import pandas as pd
 import seaborn as sns
 
 import tensorflow as tf


### PR DESCRIPTION
## Summary
- move `__future__` import to the top of `trainLin.py`

## Testing
- `python -m py_compile train.py orquestratorTrain.py orquestadorTest.py test.py stock_prediction.py parameters.py trainLin.py keylogger.py`
- `python test.py` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_684ca3116d14833080159d756f0e3e1a